### PR TITLE
fix vuex import order and upgrade nuxt 2.8.1

### DIFF
--- a/components/home/dropdown.vue
+++ b/components/home/dropdown.vue
@@ -21,8 +21,8 @@
 </template>
 
 <script>
-import Clickoutside from '@/utils/dom/clickoutside'
 import { mapState } from 'vuex'
+import Clickoutside from '@/utils/dom/clickoutside'
 
 export default {
   name: 'VDropdown',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "cross-env": "^5.2.0",
-    "nuxt": "^2.4.0",
+    "nuxt": "^2.8.1",
     "element-ui": "^2.4.11",
     "@nuxtjs/axios": "^5.3.6"
   },


### PR DESCRIPTION
修复,运行 yarn run dev 出现 import vuex 导入顺序错误
另外升级 nuxt 2.8.1最新版本